### PR TITLE
Fixing Test Container Build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG PYTHON_VERSION=3.8.1
+ARG PYTHON_VERSION=3.8.10
 FROM python:${PYTHON_VERSION}-slim-buster
 
 COPY Pipfile* ./

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 ARG PYTHON_VERSION=3.8.1
 FROM python:${PYTHON_VERSION}-slim-buster
 
-COPY Pipfile* .
-COPY test*.py .
+COPY Pipfile* ./
+COPY test*.py ./
 
 RUN pip install pipenv
 RUN pipenv install --deploy --ignore-pipfile


### PR DESCRIPTION
1. Fix the error 'When using COPY with more than one source file, the destination must be a directory and end with a /' when building the testing container.
2. Update version of python used in the Dockerfile.

### Testing

Build the container and start Selenium Grid.
```
➜  galagamesauto git:(bugfix/copy_path) ✗ docker build -f Dockerfile -t galagamesauto:latest . && docker-compose -f docker-compose-v3-dynamic-grid.yml up -d
Sending build context to Docker daemon  17.01MB
Step 1/8 : ARG PYTHON_VERSION=3.8.10
Step 2/8 : FROM python:${PYTHON_VERSION}-slim-buster
3.8.10-slim-buster: Pulling from library/python
b4d181a07f80: Pull complete 
de8ecf497b75: Pull complete 
baad0b8c8ed8: Pull complete 
c4e37d93c85d: Pull complete 
df93df0e898d: Pull complete 
Digest: sha256:6c0b171f6e4cbd880a972a36b77f18ccb03c3f32a6385e3306e289e9ddbfbcfe
Status: Downloaded newer image for python:3.8.10-slim-buster
 ---> add28abdb01c
Step 3/8 : COPY Pipfile* ./
 ---> b5154b041721
Step 4/8 : COPY test*.py ./
 ---> c3faf54d9ef0
Step 5/8 : RUN pip install pipenv
 ---> Running in ae4f7a256318
Collecting pipenv
  Downloading pipenv-2022.5.2-py2.py3-none-any.whl (3.9 MB)
Collecting certifi
  Downloading certifi-2021.10.8-py2.py3-none-any.whl (149 kB)
Collecting virtualenv-clone>=0.2.5
  Downloading virtualenv_clone-0.5.7-py3-none-any.whl (6.6 kB)
Collecting virtualenv
  Downloading virtualenv-20.14.1-py2.py3-none-any.whl (8.8 MB)
Requirement already satisfied: setuptools>=36.2.1 in /usr/local/lib/python3.8/site-packages (from pipenv) (57.0.0)
Collecting pip>=22.0.4
  Downloading pip-22.1-py3-none-any.whl (2.1 MB)
Collecting platformdirs<3,>=2
  Downloading platformdirs-2.5.2-py3-none-any.whl (14 kB)
Collecting distlib<1,>=0.3.1
  Downloading distlib-0.3.4-py2.py3-none-any.whl (461 kB)
Collecting filelock<4,>=3.2
  Downloading filelock-3.7.0-py3-none-any.whl (10 kB)
Collecting six<2,>=1.9.0
  Downloading six-1.16.0-py2.py3-none-any.whl (11 kB)
Installing collected packages: six, platformdirs, filelock, distlib, virtualenv-clone, virtualenv, pip, certifi, pipenv
  Attempting uninstall: pip
    Found existing installation: pip 21.1.3
    Uninstalling pip-21.1.3:
      Successfully uninstalled pip-21.1.3
Successfully installed certifi-2021.10.8 distlib-0.3.4 filelock-3.7.0 pip-22.1 pipenv-2022.5.2 platformdirs-2.5.2 six-1.16.0 virtualenv-20.14.1 virtualenv-clone-0.5.7
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
Removing intermediate container ae4f7a256318
 ---> 93c2521c0399
Step 6/8 : RUN pipenv install --deploy --ignore-pipfile
 ---> Running in 9d2ce749c5ad
Creating a virtualenv for this project...
Pipfile: /Pipfile
Using /usr/local/bin/python3.8 (3.8.10) to create virtualenv...
⠸ Creating virtual environment...created virtual environment CPython3.8.10.final.0-64 in 239ms
  creator CPython3Posix(dest=/root/.local/share/virtualenvs/-x-v5uFv0, clear=False, no_vcs_ignore=False, global=False)
  seeder FromAppData(download=False, pip=bundle, setuptools=bundle, wheel=bundle, via=copy, app_data_dir=/root/.local/share/virtualenv)
    added seed packages: pip==22.0.4, setuptools==62.1.0, wheel==0.37.1
  activators BashActivator,CShellActivator,FishActivator,NushellActivator,PowerShellActivator,PythonActivator

✔ Successfully created virtual environment! 
Virtualenv location: /root/.local/share/virtualenvs/-x-v5uFv0
Installing dependencies from Pipfile.lock (a4c001)...
  🐍   ▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉▉ 25/25 — 00:00:04
Removing intermediate container 9d2ce749c5ad
 ---> 0482075202db
Step 7/8 : ENV PATH="/root/.local/bin:${PATH}"
 ---> Running in 844a82277fe8
Removing intermediate container 844a82277fe8
 ---> 9a432bd6110b
Step 8/8 : CMD ["pipenv", "run", "pytest", "test_gala_games.py", "-v", "--color=yes"]
 ---> Running in 3a27c86d974b
Removing intermediate container 3a27c86d974b
 ---> e56db6edce9f
Successfully built e56db6edce9f
Successfully tagged galagamesauto:latest
Creating network "galagamesauto_default" with the default driver
Pulling selenium-hub (selenium/hub:4.1.4-20220427)...
4.1.4-20220427: Pulling from selenium/hub
8e5c1b329fe3: Pull complete
6afc05a13d18: Pull complete
d3f9bb98ca69: Pull complete
bf614464e795: Pull complete
42db6c2695a4: Pull complete
a4c9ebe69773: Pull complete
43450698714e: Pull complete
cf6a11216b5f: Pull complete
7bbb1bbae611: Pull complete
7f3bbb740cf3: Pull complete
Digest: sha256:f48603db8b9795dd851d79477da8e7e205193d7e7553bf78d045b0fd328f9b41
Status: Downloaded newer image for selenium/hub:4.1.4-20220427
Pulling node-docker (selenium/node-docker:4.1.4-20220427)...
4.1.4-20220427: Pulling from selenium/node-docker
8e5c1b329fe3: Already exists
6afc05a13d18: Already exists
d3f9bb98ca69: Already exists
bf614464e795: Already exists
42db6c2695a4: Already exists
a4c9ebe69773: Already exists
43450698714e: Already exists
cf6a11216b5f: Already exists
409d08161a50: Pull complete
8864f05f0de1: Pull complete
635eec19f9cf: Pull complete
Digest: sha256:306c2975a7bb966aa5bb7bae4943b0d6016550803baee6918ce0900cf1670099
Status: Downloaded newer image for selenium/node-docker:4.1.4-20220427
Creating selenium-hub ... done
Creating galagamesauto_node-docker_1 ... done
```

Run the tests
```
➜  galagamesauto git:(bugfix/copy_path) docker run --network="host" galagamesauto:latest
============================= test session starts ==============================
platform linux -- Python 3.8.10, pytest-7.1.2, pluggy-1.0.0 -- /root/.local/share/virtualenvs/-x-v5uFv0/bin/python
cachedir: .pytest_cache
rootdir: /
collecting ... collected 4 items

test_gala_games.py::TestGalaGames::test_launch_town_star_not_logged_in PASSED [ 25%]
test_gala_games.py::TestGalaGames::test_store_search PASSED              [ 50%]
test_gala_games.py::TestGalaGames::test_store_filter_town_star_epic_rarity PASSED [ 75%]
test_gala_games.py::TestGalaGames::test_store_filter_spider_tanks_rare_rarity PASSED [100%]
```